### PR TITLE
🔧⛮ Devcontainers, Docker & Compose Updates

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,40 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/php
+{
+  "name": "StreamVibe Back",
+  // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+  // "image": "mcr.microsoft.com/devcontainers/php:1-8.2-bullseye",
+  "dockerComposeFile": [
+    "../compose.yaml",
+    "../compose.override.yaml"
+  ],
+  "service": "app",
+  "runServices": [
+    "app",
+    "database",
+    "mailer"
+  ],
+  "overrideCommand": false,
+  "workspaceFolder": "/app",
+  // Features to add to the dev container. More info: https://containers.dev/features.
+  // "features": {},
+
+  // Configure tool-specific properties.
+
+  "customizations": {
+    "jetbrains": {
+      "backend": "PhpStorm"
+    }
+  },
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  "forwardPorts": [
+    8000,
+    5432,
+    8025
+  ],
+  // Use 'postCreateCommand' to run commands after the container is created.
+  // "postCreateCommand": "composer install"
+
+  // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+  // "remoteUser": "root"
+}

--- a/assets/react/.devcontainer/devcontainer.json
+++ b/assets/react/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/typescript-node
+{
+  "name": "Node.js & TypeScript",
+  // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:1-22-bookworm",
+  // Features to add to the dev container. More info: https://containers.dev/features.
+  "features": {
+    "ghcr.io/nikobockerman/devcontainer-features/fish-persistent-data:2": {}
+  },
+
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  "forwardPorts": [5173],
+
+  // Use 'postCreateCommand' to run commands after the container is created.
+  "postCreateCommand": "yarn install",
+  // Configure tool-specific properties.
+  "customizations": {
+    "jetbrains": {
+      "backend": "WebStorm"
+    }
+  },
+  // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+  // "remoteUser": "root"
+}

--- a/assets/react/.devcontainer/devcontainer.json
+++ b/assets/react/.devcontainer/devcontainer.json
@@ -3,23 +3,32 @@
 {
   "name": "Node.js & TypeScript",
   // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-  "image": "mcr.microsoft.com/devcontainers/typescript-node:1-22-bookworm",
+  // "image": "mcr.microsoft.com/devcontainers/typescript-node:1-22-bookworm",
+  "dockerComposeFile": [
+    "../compose.yaml",
+    "../compose.override.yaml"
+  ],
+  "service": "app",
+  "overrideCommand": false,
+  "workspaceFolder": "/app",
   // Features to add to the dev container. More info: https://containers.dev/features.
-  "features": {
-    "ghcr.io/nikobockerman/devcontainer-features/fish-persistent-data:2": {}
-  },
-
+  //  "features": {
+  //    "ghcr.io/nikobockerman/devcontainer-features/fish-persistent-data:2": {},
+  //    "ghcr.io/devcontainers/features/git:1": {}
+  //  },
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
-  "forwardPorts": [5173],
-
+  "forwardPorts": [
+    5173
+  ],
   // Use 'postCreateCommand' to run commands after the container is created.
-  "postCreateCommand": "yarn install",
+  // "postCreateCommand": "yarn install",
+
   // Configure tool-specific properties.
   "customizations": {
     "jetbrains": {
       "backend": "WebStorm"
     }
-  },
+  }
   // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
   // "remoteUser": "root"
 }

--- a/assets/react/.dockerignore
+++ b/assets/react/.dockerignore
@@ -1,5 +1,4 @@
 # Self docker
-.git
 docker/Dockerfile
 docker-compose.yaml
 docker-compose.override.yaml

--- a/assets/react/.dockerignore
+++ b/assets/react/.dockerignore
@@ -1,3 +1,9 @@
+# Self docker
+.git
+docker/Dockerfile
+docker-compose.yaml
+docker-compose.override.yaml
+
 # Logs
 logs
 *.log

--- a/assets/react/compose.override.yaml
+++ b/assets/react/compose.override.yaml
@@ -1,0 +1,11 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
+      target: base
+    environment:
+      NODE_ENV: development
+    ports:
+      - "5173:5173"
+    command: [ "yarn", "dev", "--host", "0.0.0.0" ]

--- a/assets/react/compose.override.yaml
+++ b/assets/react/compose.override.yaml
@@ -6,6 +6,8 @@ services:
       target: base
     environment:
       NODE_ENV: development
+    volumes:
+      - ./node_modules:/app/node_modules
     ports:
       - "5173:5173"
     command: [ "yarn", "dev", "--host", "0.0.0.0" ]

--- a/assets/react/compose.yaml
+++ b/assets/react/compose.yaml
@@ -1,0 +1,12 @@
+services:
+  app:
+    container_name: react_app
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
+      target: prod
+    ports:
+      - "5173:5173"
+    environment:
+      - NODE_ENV=production
+    restart: unless-stopped

--- a/assets/react/docker/Dockerfile
+++ b/assets/react/docker/Dockerfile
@@ -1,0 +1,29 @@
+# ---- Stage 1: Build ----
+FROM node:20-slim AS base
+
+WORKDIR /app
+
+# Copy only dependency files first to leverage Docker cache
+COPY package.json yarn.lock ./
+
+# Set Yarn cache folder and install dependencies
+ENV YARN_CACHE_FOLDER=/usr/local/share/.yarn-cache
+RUN mkdir -p $YARN_CACHE_FOLDER && yarn install --immutable
+
+# Copy the rest of the project and build
+COPY . .
+
+# ---- build stage (production build) ----
+FROM base AS build
+# run build (produces /app/dist)
+RUN yarn build
+
+# ---- prod stage (lightweight runtime) ----
+FROM node:20-slim AS prod
+WORKDIR /app
+
+# copy only dist from build stage (no source, minimal)
+COPY --from=build /app/dist /app/dist
+
+# Use a lightweight static server; npx serve avoids global install
+CMD ["npx", "serve", "-s", "dist", "-l", "5173"]

--- a/assets/react/docker/Dockerfile
+++ b/assets/react/docker/Dockerfile
@@ -10,6 +10,9 @@ COPY package.json yarn.lock ./
 ENV YARN_CACHE_FOLDER=/usr/local/share/.yarn-cache
 RUN mkdir -p $YARN_CACHE_FOLDER && yarn install --immutable
 
+# apt install
+RUN apt update -y && apt install curl git fish neovim -y
+
 # Copy the rest of the project and build
 COPY . .
 

--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -20,5 +20,7 @@ services:
 ###< symfony/mailer ###
 
   app:
+    volumes:
+      - ./vendor:/app/vendor
     environment:
       APP_ENV: dev

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,8 +22,8 @@ COPY . .
 RUN composer install
 
 # Ajustes de scripts
-COPY --chmod=0755 docker/scripts/entrypoint.sh ./docker/scripts/entrypoint.sh
-RUN dos2unix ./docker/scripts/entrypoint.sh
+RUN dos2unix /app/docker/scripts/entrypoint.sh
+RUN chmod 751 /app/docker/scripts/entrypoint.sh
 
-ENTRYPOINT ["./docker/scripts/entrypoint.sh"]
+ENTRYPOINT ["/app/docker/scripts/entrypoint.sh"]
 CMD ["symfony", "serve:start", "--allow-all-ip"]

--- a/docker/scripts/entrypoint.sh
+++ b/docker/scripts/entrypoint.sh
@@ -30,14 +30,14 @@ VARIAVEIS=(
   # Adicione mais aqui
 )
 
+symfony console secrets:decrypt-to-local --force
+
 # Processa todas
 for item in "${VARIAVEIS[@]}"; do
     VAR_NAME=$(echo "$item" | cut -d':' -f1)
     NEW_HOST=$(echo "$item" | cut -d':' -f2)
     update_env_var "$VAR_NAME" "$NEW_HOST"
 done
-
-symfony console secrets:decrypt-to-local --force
 
 symfony console doctrine:migrations:migrate --no-interaction
 


### PR DESCRIPTION
# 🔧⛮ Devcontainers, Docker & Compose Updates

This PR improves containerization for both backend (Symfony) and frontend (React) by refining Dockerfiles, devcontainers, and compose setups.

---

## ✅ Backend (Symfony)

- [x] `chore`: 🤖 Add `.devcontainer/devcontainer.json`  
  - Configured with `dockerComposeFile: ["../compose.yaml", "../compose.override.yaml"]`  
  - Service set to `"app"`, with `runServices: ["app", "database", "mailer"]`  
  - Workspace folder `/app`, `overrideCommand: false`  
  - JetBrains backend set to `PhpStorm`  
  - Forwarded ports: 8000 (app), 5432 (db), 8025 (mailer)  
  - Optional `composer install` post-create command (commented)  

- [x] `chore`: 🤖 Update `compose.override.yaml`  
  - Mount vendor as volume: `./vendor:/app/vendor`

- [x] `chore`: 🤖 Update backend Dockerfile entrypoint handling  
  - Applied `dos2unix` on `/app/docker/scripts/entrypoint.sh`  
  - Set permissions with `chmod 751`  
  - Updated `ENTRYPOINT` to use absolute path  

- [x] `fix`: 🐛 Ensure backend env variables load correctly  
  - Decrypt secrets (`symfony console secrets:decrypt-to-local --force`) **before** processing env vars  
  - Prevents `DATABASE_URL` missing issues

---

## ✅ Frontend (React)

- [x] `feat`: 🎸 Containerize React app with multi-stage Dockerfile  
  - `base` → install deps & tooling (`curl`, `git`, `fish`, `neovim`)  
  - `build` → run `yarn build`, output `/app/dist`  
  - `prod` → serve static build via `npx serve -s dist -l 5173`  

- [x] `chore`: 🤖 Add `.dockerignore` (leaner build context)  
  - Ignores VCS, compose files, logs, caches, `node_modules`, `dist*`, Yarn PnP artifacts, and editor metadata  

- [x] `chore`: 🤖 Update `.gitignore`  
  - Added Yarn PnP entries (`.pnp.cjs`, `.pnp.loader.mjs`, `.yarn`)  

- [x] `chore`: 🤖 Add production `compose.yaml`  
  - Service `app`, target `prod`, `NODE_ENV=production`  
  - Ports `5173:5173`, `restart: unless-stopped`  

- [x] `chore`: 🤖 Add development `compose.override.yaml`  
  - Service `app`, target `base`  
  - Mounted `./node_modules:/app/node_modules`  
  - Command: `yarn dev --host 0.0.0.0` for HMR  

- [x] `chore`: 🤖 Update React devcontainer  
  - Switched from fixed Node image to Docker Compose setup  
  - Service `app`, workspace `/app`, `overrideCommand: false`  
  - Features (Fish + Git) commented for optional use  
  - JetBrains backend: `WebStorm`  
  - Forwarded port: `5173`  
  - Commented out auto `yarn install` post-create 