### PR TITLE
🐛 Fix Entrypoint Permissions & Enable Composer Install in Devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -33,7 +33,7 @@
     8025
   ],
   // Use 'postCreateCommand' to run commands after the container is created.
-  // "postCreateCommand": "composer install"
+  "postCreateCommand": "composer install"
 
   // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
   // "remoteUser": "root"

--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -20,7 +20,5 @@ services:
 ###< symfony/mailer ###
 
   app:
-    volumes:
-      - ./vendor:/app/vendor
     environment:
       APP_ENV: dev


### PR DESCRIPTION
# 🐛 Enable and ensure Composer Install Dependencies inside Devcontainer in `vendor/`

This PR ensures PHP dependencies are installed automatically when creating the devcontainer.

---

## ✅ Changes

- [x] `fix`: 🐛 Enable `postCreateCommand` in `.devcontainer/devcontainer.json` and Prevents Symfony application startup error
  - Runs `composer install` after container creation
  - Remove mount volume ./vendor:/app/vendor
  - Prevents Symfony failed to load because dependencies were missing:
    - `HTTP 500 Internal Server Error when accessing routes (missing vendor/)`

---

## 💡 Why
  
- Prevents Symfony application startup errors due to missing `vendor/` dependencies.  
- Ensures a consistent devcontainer environment by automatically installing PHP dependencies.  
- Improves developer experience by removing manual setup steps after container creation.  
